### PR TITLE
Renaming zip file for download

### DIFF
--- a/interfaces/web.go
+++ b/interfaces/web.go
@@ -30,7 +30,7 @@ func (handler WebServiceHandler) CreateConfig(res http.ResponseWriter, req *http
 	server = mainJSON.Server
 
 	res.Header().Set("Content-Type", "application/zip")
-	res.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", "algo"))
+	res.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", "puppet.zip"))
 	handler.EngineInteractor.CreateConf(server, res)
 
 }


### PR DESCRIPTION
closes #8 

For the moment being, it will use just puppet.zip, we need to create another way to name these files.
